### PR TITLE
Dashboard.js: Bump firmware version to 2.2.0

### DIFF
--- a/React/src/components/Dashboard/Dashboard.js
+++ b/React/src/components/Dashboard/Dashboard.js
@@ -86,7 +86,7 @@ class Dashboard extends React.Component {
     if (this.props.connected) {
       if (this.state.firmware === "" || this.state.firmware === undefined) {
         routes = <div className="loading_dashboard"><div><LoadingIcon /></div></div>;
-      } else if (this.state.firmware !== "v2.1.0") {
+      } else if (this.state.firmware !== "v2.2.0") {
         routes = <div className="loading_dashboard"><div><UpdateFirmware /></div></div>;
       } else {
         routes = (


### PR DESCRIPTION
Bump the firmware version check to align with the latest release, v0.2.2, so that the webapp can be used with Thingy:52s on latest firmware.